### PR TITLE
Truffle406

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ openssl rsa -pubout < test_private.key > test_public.key
 
 ### Running locally
 
-- Run `npm run truffle migrate`
+- Run `./node_modules/.bin/truffle truffle migrate`
 - Run `npm run dev`
 - Open `http://localhost:8080`
 
@@ -154,7 +154,7 @@ Event name is configurable as `name`
 First, deploy the contract.
 
 ```
-npm run truffle migrate --config '{"name":"CodeUp No..", "encryption":"./tmp/test_public.key", "confirmation":true}'
+./node_modules/.bin/truffle migrate --config '{"name":"CodeUp No..", "encryption":"./tmp/test_public.key", "confirmation":true}'
 ```
 
 As an example, assume you have the following two codes at `input.txt`

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ openssl genrsa 2048 > test_private.key
 openssl rsa -pubout < test_private.key > test_public.key
 ```
 
-- Run `truffle test --network test`
+- Run `npm run test`
 
 ### Running test coverage
 
@@ -127,7 +127,7 @@ openssl rsa -pubout < test_private.key > test_public.key
 
 ### Running locally
 
-- Run `truffle migrate`
+- Run `npm run truffle migrate`
 - Run `npm run dev`
 - Open `http://localhost:8080`
 
@@ -154,7 +154,7 @@ Event name is configurable as `name`
 First, deploy the contract.
 
 ```
-truffle migrate --config '{"name":"CodeUp No..", "encryption":"./tmp/test_public.key", "confirmation":true}'
+npm run truffle migrate --config '{"name":"CodeUp No..", "encryption":"./tmp/test_public.key", "confirmation":true}'
 ```
 
 As an example, assume you have the following two codes at `input.txt`
@@ -168,7 +168,7 @@ $ cat tmp/input.txt
 Running `repository.js` will add these confirmation code into the ConfirmationRepository.
 
 ```
-$truffle exec scripts/repository.js -t confirmation -i tmp/input.txt
+$npm run truffle exec scripts/repository.js -t confirmation -i tmp/input.txt
 Adding 1234567890  as  0xf654274a8983066b9f810ed158b3fa883c9d26553429193e4aba65b44b76c835
 Adding 0987654321  as  0x295153b1a40cec2698cd2fb0d75c8137a5c43d67ed5e4b7abbd463bc2b0dfac7
 ```
@@ -176,7 +176,7 @@ Adding 0987654321  as  0x295153b1a40cec2698cd2fb0d75c8137a5c43d67ed5e4b7abbd463b
 If you run the same program again, it will detect.
 
 ```
-$truffle exec scripts/repository.js -t confirmation -i input.txt
+$npm run truffle exec scripts/repository.js -t confirmation -i input.txt
 Using network 'development'.
 
 code 1234567890  is already registered. Claimed by  0x0000000000000000000000000000000000000000
@@ -186,7 +186,7 @@ code 0987654321  is already registered. Claimed by  0x00000000000000000000000000
 Pass the original confirmation ion codes to the participants. Once participants use the code to register, you can check who used the codes by running the script again.
 
 ```
-$truffle exec scripts/repository.js -t confirmation -i input.txt
+$npm run truffle exec scripts/repository.js -t confirmation -i input.txt
 Using network 'development'.
 
 code 1234567890  is already registered. Claimed by 0x12ff7cfb557a7d0404b694da8d6106e219306a93

--- a/contracts/Conference.sol
+++ b/contracts/Conference.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.18;
+pragma solidity ^0.4.19;
 
 import './ConfirmationRepository.sol';
 import './zeppelin/ownership/Ownable.sol';

--- a/contracts/ConfirmationRepository.sol
+++ b/contracts/ConfirmationRepository.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.18;
+pragma solidity ^0.4.19;
 
 import './InvitationRepository.sol';
 

--- a/contracts/InvitationRepository.sol
+++ b/contracts/InvitationRepository.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.18;
+pragma solidity ^0.4.19;
 
 import './zeppelin/ownership/Ownable.sol';
 

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.18;
+pragma solidity ^0.4.19;
 
 contract Migrations {
   address public owner;
@@ -8,15 +8,15 @@ contract Migrations {
     if (msg.sender == owner) _;
   }
 
-  function Migrations() {
+  function Migrations() public {
     owner = msg.sender;
   }
 
-  function setCompleted(uint completed) restricted {
+  function setCompleted(uint completed) restricted public{
     last_completed_migration = completed;
   }
 
-  function upgrade(address new_address) restricted {
+  function upgrade(address new_address) restricted public{
     Migrations upgraded = Migrations(new_address);
     upgraded.setCompleted(last_completed_migration);
   }

--- a/contracts/zeppelin/lifecycle/Destructible.sol
+++ b/contracts/zeppelin/lifecycle/Destructible.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.18;
+pragma solidity ^0.4.19;
 
 
 import "../ownership/Ownable.sol";

--- a/contracts/zeppelin/ownership/Ownable.sol
+++ b/contracts/zeppelin/ownership/Ownable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.18;
+pragma solidity ^0.4.19;
 
 
 /**

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
   "scripts": {
     "lint": "eslint ./",
     "build": "webpack -p",
+    "truffle": "./node_modules/.bin/truffle",
+    "test": " ./node_modules/.bin/truffle test --network test",
     "dev": "webpack-dev-server -d --inline --hot",
     "coverage": "./node_modules/.bin/solidity-coverage",
     "build-contracts": "sol-merger './contracts/*.sol' ./build"
@@ -54,6 +56,7 @@
     "react-tap-event-plugin": "^1.0.0",
     "sol-merger": "^0.1.2",
     "style-loader": "^0.13.1",
+    "truffle": "^4.0.6",
     "truffle-contract": "^3.0.0",
     "truffle-hdwallet-provider": "0.0.3",
     "url-loader": "^0.5.7",

--- a/test/conference.js
+++ b/test/conference.js
@@ -19,7 +19,7 @@ contract('Conference', function(accounts) {
   let conference, deposit;
 
   beforeEach(async function(){
-    conference = await Conference.new();
+    conference = await Conference.new('', 0, 0, 0, 0, '');
     deposit = (await conference.deposit.call()).toNumber();
   })
 


### PR DESCRIPTION
This PR includes the following changes. cc @jefflau 

- Add truffle to package.json
- Upgrade solc to 0.4.19
- Add `public` to silence solc warning

NOTE: Now most command can be run via `npm run truffle` except migration as it is failing to take `--config` as an argument properly.